### PR TITLE
Disabling authentication for gql

### DIFF
--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -36,7 +36,7 @@ export default (app: App) => {
         where: { visibility: COMMUNITY_VISIBILITY_PUBLIC },
       });
     },
-    findPopularCommunities: () => {
+    popularCommunities: () => {
       // returns communities with most members
       return app.models.Community.findAll({
         limit: 10,

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -81,7 +81,7 @@ export default gql`
     getLoggedInUserCommunities: [Community]
     getUserCommunitiesByUuid(uuid: ID!): [Community]
     searchCommunities(name: String!): [Community]
-    findPopularCommunities: [PopularCommunity]
+    popularCommunities: [PopularCommunity]
   }
 
   type Mutation {

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -16,13 +16,11 @@ import config from '$/config';
 import { getAllFiles } from './helpers';
 import DbClient, { importModels } from './db-client';
 
-import authenticationMiddleware from '$/middlewares/auth';
 import gqlSchema from '$/graphql/schema';
 import gqlResolvers from '$/graphql/resolvers';
 
 import LocalPassportStrategy from '$/passport-auth/local-strategy';
 import JwtPassportStrategy from '$/passport-auth/jwt-strategy';
-import { generateTokenForUser } from '$/passport-auth/lib';
 
 export default class App {
   routesPath: string;
@@ -185,8 +183,10 @@ export default class App {
       context: ({ req }) => req.user,
     };
 
-    /* TODO: authenticate users in the resolvers */
-    /*
+    /* TODO: authenticate users in the resolvers
+    import authenticationMiddleware from '$/middlewares/auth';
+    import { generateTokenForUser } from '$/passport-auth/lib';
+
     express.use((req: exExpress$Request, res: express$Response, next: express$NextFunction) => {
       if (req.path === that.config.gqlServer.rootPath) {
         return authenticationMiddleware(req, res, next);

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -185,6 +185,8 @@ export default class App {
       context: ({ req }) => req.user,
     };
 
+    /* TODO: authenticate users in the resolvers */
+    /*
     express.use((req: exExpress$Request, res: express$Response, next: express$NextFunction) => {
       if (req.path === that.config.gqlServer.rootPath) {
         return authenticationMiddleware(req, res, next);
@@ -199,6 +201,7 @@ export default class App {
       }
       return next();
     });
+     */
 
     const server = new ApolloServer(serverConf);
     server.applyMiddleware({ app: express, path: this.config.gqlServer.rootPath });


### PR DESCRIPTION
See:
https://github.com/Kommunity-app/kommunity-frontend/pull/135

@MustafaOnurKilinc we dont need to use verbs for the endpoints name, so instead of findPopularCommunities, lets call it popularCommunities